### PR TITLE
Meilleure intégration Colab / Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@ It is based on the following Kaggle competition:
 
 <p align="center"> <img src = "./resources/cloud_example.png"/ class="center"> </p>
 
+# Explore the project
+
+<p>To explore our work, just click the badges "Open In Colab" below.</p>
+<ul type="circle">
+<li>Explore phase 1 notebook in Google Colab (<i>nebula_phase1_dataAnalyse.ipynb</i>)</li>
+<p align="center"><a href="https://colab.research.google.com/github/DataScientest/nebula/blob/yann/nebula_phase1_dataAnalyse.ipynb" target="new" rel="noopener noreferrer">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a></p>
+<li>Explore phase 2 notebook in Google Colab (<i>nebula_phase2_multiClassification.ipynb</i>)</li>
+<p align="center"><a href="https://colab.research.google.com/github/DataScientest/nebula/blob/yann/nebula_phase2_multiClassification.ipynb" target="new" rel="noopener noreferrer">
+  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a></p>
+</ul>
+<p style="text-indent:20px;">More to come...</p>
+<p></p>
+
+<p>Notes:</p>
+<ul type="circle">
+<li>Should nothing happen after a click, right-click the badge, then "open in new tab".</li>
+<li>Google Colab will require access to your Github account on your first access.</li>
+</ul>
 
 # Us
 


### PR DESCRIPTION
Ajout de liens vers Colab dans le readme.md
Le notebook phase2 vient directement récupérer le contenu de la librairie projet dans Github